### PR TITLE
Add filterIsA and filterIsOneOf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "5.7.*"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.7.*"
+        "phpunit/phpunit": "5.7.*"
     },
     "autoload": {
         "psr-0": { "PhpOption\\": "src/" }

--- a/src/PhpOption/LazyOption.php
+++ b/src/PhpOption/LazyOption.php
@@ -126,6 +126,16 @@ final class LazyOption extends Option
         return $this->option()->filterNot($callable);
     }
 
+    public function filterIsA($class)
+    {
+        return $this->option()->filterIsA($class);
+    }
+
+    public function filterIsOneOf(...$classes)
+    {
+        return $this->option()->filterIsOneOf($classes);
+    }
+
     public function select($value)
     {
         return $this->option()->select($value);

--- a/src/PhpOption/None.php
+++ b/src/PhpOption/None.php
@@ -101,6 +101,16 @@ final class None extends Option
         return $this;
     }
 
+    public function filterIsA($class)
+    {
+      return $this;
+    }
+
+    public function filterIsOneOf(...$classes)
+    {
+      return $this;
+    }
+
     public function select($value)
     {
         return $this;

--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -291,6 +291,29 @@ abstract class Option implements IteratorAggregate
     abstract public function filterNot($callable);
 
     /**
+     * Check if the option is an instanceof or subclass of the given parameter
+     *
+     * @param string $class
+     *
+     * @return Option
+     */
+    abstract public function filterIsA($class);
+
+    /**
+     * Check if the option is an instanceof or subclass of any of the given parameters.
+     * If the first parameter is an array, all elements of the array are checked instead.
+     * Example:
+     * $opt = Option::fromValue(new stdClass());
+     * $opt->filterIsOneOf("unknown_type", stdClass::class) == true
+     * $opt->filterIsOneOf(["unknown_type", stdClass::class]) == true
+     *
+     * @param string $classes
+     *
+     * @return Option
+     */
+    abstract public function filterIsOneOf(...$classes);
+
+    /**
      * If the option is empty, it is returned immediately.
      *
      * If the option is non-empty, and its value does not equal the passed value

--- a/src/PhpOption/Some.php
+++ b/src/PhpOption/Some.php
@@ -132,7 +132,7 @@ final class Some extends Option
             return None::create();
         }
 
-        if (is_array($classes[0])) {
+        if (is_array($classes[0]) || $classes[0] instanceof \Traversable) {
             $classes = $classes[0];
         }
 
@@ -142,7 +142,7 @@ final class Some extends Option
             }
         }
 
-        return None::create();;
+        return None::create();
     }
 
     public function select($value)

--- a/src/PhpOption/Some.php
+++ b/src/PhpOption/Some.php
@@ -117,6 +117,34 @@ final class Some extends Option
         return None::create();
     }
 
+    public function filterIsA($class)
+    {
+        if (is_a($this->value, $class)) {
+            return $this;
+        }
+
+        return None::create();
+    }
+
+    public function filterIsOneOf(...$classes)
+    {
+        if (count($classes) < 1) {
+            return None::create();
+        }
+
+        if (is_array($classes[0])) {
+            $classes = $classes[0];
+        }
+
+        foreach($classes as $class) {
+            if (is_a($this->value, $class)) {
+                return $this;
+            }
+        }
+
+        return None::create();;
+    }
+
     public function select($value)
     {
         if ($this->value === $value) {

--- a/tests/PhpOption/Tests/NoneTest.php
+++ b/tests/PhpOption/Tests/NoneTest.php
@@ -92,6 +92,17 @@ class NoneTest extends \PHPUnit_Framework_TestCase
         }));
     }
 
+    public function testFilterIsA()
+    {
+      $this->assertSame($this->none, $this->none->filterIsA(stdClass::class));
+    }
+
+    public function testFilterIsOneOf()
+    {
+      $this->assertSame($this->none, $this->none->filterIsOneOf(stdClass::class));
+      $this->assertSame($this->none, $this->none->filterIsOneOf([stdClass::class]));
+    }
+
     public function testSelect()
     {
         $this->assertSame($this->none, $this->none->select(null));

--- a/tests/PhpOption/Tests/SomeTest.php
+++ b/tests/PhpOption/Tests/SomeTest.php
@@ -88,6 +88,25 @@ class SomeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($some, $some->filterNot(function($v) { return strlen($v) === 0; }));
     }
 
+    public function testFilterIsA()
+    {
+        $some = new Some(new \stdClass());
+
+        $this->assertInstanceOf('PhpOption\None', $some->filterIsA('unknown'));
+        $this->assertSame($some, $some->filterIsA(\stdClass::class));
+    }
+
+    public function testFilterIsOneOf()
+    {
+      $some = new Some(new \stdClass());
+
+      $this->assertInstanceOf('PhpOption\None', $some->filterIsOneOf('unknown', 'unknown2'));
+      $this->assertInstanceOf('PhpOption\None', $some->filterIsOneOf(['unknown', 'unknown2']));
+
+      $this->assertSame($some, $some->filterIsOneOf(\stdClass::class, 'unknown'));
+      $this->assertSame($some, $some->filterIsOneOf([\stdClass::class, 'unknown']));
+    }
+
     public function testSelect()
     {
         $some = new Some('foo');

--- a/tests/PhpOption/Tests/SomeTest.php
+++ b/tests/PhpOption/Tests/SomeTest.php
@@ -105,6 +105,7 @@ class SomeTest extends \PHPUnit_Framework_TestCase
 
       $this->assertSame($some, $some->filterIsOneOf(\stdClass::class, 'unknown'));
       $this->assertSame($some, $some->filterIsOneOf([\stdClass::class, 'unknown']));
+      $this->assertSame($some, $some->filterIsOneOf(new \ArrayIterator([\stdClass::class, 'unknown'])));
     }
 
     public function testSelect()


### PR DESCRIPTION
Allows us to filter more easily on the Option's value's type. For example:

`
$x = new Task();
$opt = Option::ensure($x);
$opt->filterIsA(Task::class);
`
or if we need to filter multiple types
`
$x = new Task();
$opt = Option::ensure($x);
$opt->filterIsOneOf(Task::class, File::class);
`